### PR TITLE
[LR-402] - make the calendar widget a little bigger

### DIFF
--- a/src/stylesheets/variables.scss
+++ b/src/stylesheets/variables.scss
@@ -18,6 +18,6 @@ $datepicker__border-radius: 0.3rem !default;
 $datepicker__day-margin: 0.166rem !default;
 $datepicker__font-size: 0.8rem !default;
 $datepicker__font-family: "Gotham SSm A", "Gotham SSm B", sans-serif !default;
-$datepicker__item-size: 1.7rem !default;
+$datepicker__item-size: clamp(1.5rem, 12vw, 2.5rem) !default;
 $datepicker__margin: 0.4rem !default;
 $datepicker__navigation-button-size: 32px !default;


### PR DESCRIPTION
Some changes just to make this a little bigger, especially on mobile so the days are more finger sized.

<img width="659" height="538" alt="Screenshot 2025-07-10 at 8 40 20 AM" src="https://github.com/user-attachments/assets/b25b5765-fbc1-450e-a90f-1df7089598a7" />

<img width="430" height="726" alt="Screenshot 2025-07-10 at 8 47 02 AM" src="https://github.com/user-attachments/assets/f3cb5239-04e3-4b78-9289-12d642c9e479" />
